### PR TITLE
fix: prevent global namespace contaminate

### DIFF
--- a/simaple/spec/patch.py
+++ b/simaple/spec/patch.py
@@ -126,7 +126,7 @@ class EvalPatch(DFSTraversePatch):
         return match.group(1)
 
     def _evaluate_with_math(self, value):
-        global_variables = globals()
+        global_variables = {}
         global_variables.update(self.injected_values)
         global_variables["math"] = math
 


### PR DESCRIPTION
global variable이 필요 없음에도 초기화를 globals() 로 하여 전역 변수 공간이 오염되는 버그를 해소합니다.