### PR TITLE
feat: handle keydown

### DIFF
--- a/simaple/data/skill/resources/components/archmagetc.yaml
+++ b/simaple/data/skill/resources/components/archmagetc.yaml
@@ -171,6 +171,7 @@ data:
   delay: 240
   cooldown_duration: 60_000
 
+  keydown_prepare_delay: 780
   keydown_end_delay: 1080
 
   finish_damage: 780

--- a/simaple/data/skill/resources/components/archmagetc.yaml
+++ b/simaple/data/skill/resources/components/archmagetc.yaml
@@ -168,7 +168,7 @@ data:
 
   damage: 150
   hit: 15
-  delay: 240
+  delay: 210
   cooldown_duration: 60_000
 
   keydown_prepare_delay: 780

--- a/simaple/data/skill/resources/components/bishop.yaml
+++ b/simaple/data/skill/resources/components/bishop.yaml
@@ -254,6 +254,7 @@ data:
   delay: 1020
   cooldown_duration: 68_000
 
+  keydown_prepare_delay: 240
   keydown_end_delay: 720
 
   finish_damage: 0

--- a/simaple/data/skill/resources/components/mechanic.yaml
+++ b/simaple/data/skill/resources/components/mechanic.yaml
@@ -294,7 +294,7 @@ data:
   cooldown_duration: 25_000
 ---
 kind: Component
-version: simaple.io/KeydownSkillComponent
+version: simaple.io/FullMetalBarrageComponent
 metadata:
   label:
     group: mechanic
@@ -311,10 +311,10 @@ data:
   delay: 200
   cooldown_duration: 200_000
 
+  keydown_prepare_delay: 1330 # TODO: 1350으로 올림되는지 확인 필요
   keydown_end_delay: 1800
 
-  finish_damage: 0
-  finish_hit: 0
+  homing_penalty_duration: 2000
 ---
 kind: Component
 version: simaple.io/MecaCarrier

--- a/simaple/simulate/actor.py
+++ b/simaple/simulate/actor.py
@@ -1,9 +1,11 @@
 from abc import ABCMeta
 from contextlib import contextmanager
+from typing import Optional
 
 import pydantic
 
 from simaple.simulate.base import Action, Environment, Event
+from simaple.simulate.component.view import KeydownView, Running, Validity
 from simaple.simulate.reserved_names import Tag
 
 
@@ -31,48 +33,97 @@ class Actor(metaclass=ABCMeta):
         ...
 
 
-class AlwaysDelayedActor(Actor):
-    def decide(self, environment: Environment, events: list[Event]) -> Action:
-        for event in events:
-            if event.tag in (Tag.DELAY,) and event.payload["time"] > 0:
-                return time_elapsing_action(event.payload["time"])
-
-        return self._decide(environment, events)
-
-    def _decide(self, environment: Environment, events: list[Event]) -> Action:
-        ...
-
-
-class DefaultMDCActor(pydantic.BaseModel, AlwaysDelayedActor):
+class DefaultMDCActor(pydantic.BaseModel, Actor):
     order: list[str]
 
-    def _decide(self, environment: Environment, events: list[Event]) -> Action:
-        validities = environment.show("validity")
-        runnings = environment.show("running")
-        keydowns = environment.show("keydown")
+    def _decide_during_keydown(
+        self,
+        validity_map: dict[str, Validity],
+        running_map: dict[str, float],
+        keydown_running_name: str,
+        elapse_time: float,
+    ):
+        for name in self.order:
+            if name == keydown_running_name:
+                break
 
-        validity_map = {v.name: v for v in validities if v.valid}
-        running_map = {r.name: r.time_left for r in runnings}
-        keydown_running_list = [k for k in keydowns if k.running]
+            if validity_map.get(name):
+                if running_map.get(name, 0) > 0:
+                    continue
 
-        if len(keydown_running_list) > 1:
-            raise ValueError("Running keydown cannot be more than 1")
+                return Action(name=keydown_running_name, method="stop")
+
+        return time_elapsing_action(elapse_time)
+
+    def _decide_default(
+        self,
+        validity_map: dict[str, Validity],
+        running_map: dict[str, float],
+        elapse_time: float,
+    ):
+        if elapse_time > 0:
+            return time_elapsing_action(elapse_time)
 
         for name in self.order:
             if validity_map.get(name):
                 if running_map.get(name, 0) > 0:
                     continue
 
-                return Action(
-                    name=name,
-                    method="use",
-                )
+                return Action(name=name, method="use")
 
-        for v in validities:
+        for v in validity_map.values():
             if v.valid:
-                return Action(
-                    name=v.name,
-                    method="use",
-                )
+                return Action(name=v.name, method="use")
 
-        raise ValueError("No valid element exist! Maybe wrong component build?")
+        return None
+
+    def decide(
+        self,
+        environment: Environment,
+        events: list[Event],
+    ) -> Action:
+        validities: list[Validity] = environment.show("validity")
+        runnings: list[Running] = environment.show("running")
+
+        validity_map = {v.name: v for v in validities if v.valid}
+        running_map = {r.name: r.time_left for r in runnings}
+        keydown_running_name = self._get_keydown_running_name(environment)
+        elapse_time = self._get_next_elapse_time(events)
+
+        chosen_action: Optional[Action] = None
+
+        if keydown_running_name is not None:
+            chosen_action = self._decide_during_keydown(
+                validity_map,
+                running_map,
+                keydown_running_name,
+                elapse_time,
+            )
+        else:
+            chosen_action = self._decide_default(
+                validity_map,
+                running_map,
+                elapse_time,
+            )
+
+        if chosen_action:
+            return chosen_action
+
+        raise ValueError(
+            "No valid element exist! Maybe unintended component was built?"
+        )
+
+    def _get_keydown_running_name(self, environment: Environment) -> Optional[str]:
+        keydowns: list[KeydownView] = environment.show("keydown")
+        keydown_running_list = [k.name for k in keydowns if k.running]
+
+        if len(keydown_running_list) > 1:
+            raise ValueError("Running keydown cannot be more than 1")
+        return next(iter(keydown_running_list), None)
+
+    def _get_next_elapse_time(self, events: list[Event]) -> float:
+        for event in events:
+            if event.tag in (Tag.DELAY,) and event.payload["time"] > 0:
+                return event.payload["time"]  # type: ignore
+
+        return 0.0

--- a/simaple/simulate/actor.py
+++ b/simaple/simulate/actor.py
@@ -49,9 +49,14 @@ class DefaultMDCActor(pydantic.BaseModel, AlwaysDelayedActor):
     def _decide(self, environment: Environment, events: list[Event]) -> Action:
         validities = environment.show("validity")
         runnings = environment.show("running")
+        keydowns = environment.show("keydown")
 
         validity_map = {v.name: v for v in validities if v.valid}
-        running_map = {d.name: d.time_left for d in runnings}
+        running_map = {r.name: r.time_left for r in runnings}
+        keydown_running_list = [k for k in keydowns if k.running]
+
+        if len(keydown_running_list) > 1:
+            raise ValueError("Running keydown cannot be more than 1")
 
         for name in self.order:
             if validity_map.get(name):

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -112,3 +112,36 @@ class Stack(Entity):
 
     def decrease(self, value: int = 1):
         self.stack -= value
+
+
+class Keydown(Entity):
+    interval: float
+    interval_counter: float = 0.0
+    time_left: float = 0
+
+    @property
+    def running(self) -> bool:
+        return self.time_left > 0
+
+    def start(self, maximum_keydown_time: float, prepare_delay: float):
+        self.interval_counter = prepare_delay
+        self.time_left = maximum_keydown_time
+
+    def stop(self):
+        self.time_left = 0
+
+    def resolving(self, time: float):
+        resolving_time_left = self.time_left - max(0, self.interval_counter)
+        self.time_left -= time
+        self.interval_counter -= time
+
+        # pylint:disable=chained-comparison
+        while resolving_time_left >= 0 and self.interval_counter <= 0:
+            is_last = resolving_time_left < self.interval
+            if is_last:
+                yield resolving_time_left
+            else:
+                yield self.interval
+
+            self.interval_counter += self.interval
+            resolving_time_left -= self.interval

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -140,6 +140,6 @@ class Keydown(Entity):
 
         # pylint:disable=chained-comparison
         while resolving_time_left >= 0 and self.interval_counter <= 0:
-            yield 1
+            yield
             self.interval_counter += self.interval
             resolving_time_left -= self.interval

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -123,6 +123,9 @@ class Keydown(Entity):
     def running(self) -> bool:
         return self.time_left > 0
 
+    def get_next_delay(self) -> float:
+        return min(self.interval_counter, self.time_left)
+
     def start(self, maximum_keydown_time: float, prepare_delay: float):
         self.interval_counter = prepare_delay
         self.time_left = maximum_keydown_time
@@ -137,11 +140,6 @@ class Keydown(Entity):
 
         # pylint:disable=chained-comparison
         while resolving_time_left >= 0 and self.interval_counter <= 0:
-            is_last = resolving_time_left < self.interval
-            if is_last:
-                yield resolving_time_left
-            else:
-                yield self.interval
-
+            yield 1
             self.interval_counter += self.interval
             resolving_time_left -= self.interval

--- a/simaple/simulate/component/keydown_skill.py
+++ b/simaple/simulate/component/keydown_skill.py
@@ -44,12 +44,12 @@ class KeydownSkillComponent(SkillComponent, KeydownSkillTrait, CooldownValidityT
 
     @reducer_method
     def elapse(self, time: float, state: KeydownSkillState):
-        state, events, _ = self.elapse_keydown_trait(time, state)
+        state, events = self.elapse_keydown_trait(time, state)
         return state, events
 
     @reducer_method
     def stop(self, _, state: KeydownSkillState):
-        state, events, _ = self.stop_keydown_trait(state)
+        state, events = self.stop_keydown_trait(state)
         return state, events
 
     @view_method

--- a/simaple/simulate/component/keydown_skill.py
+++ b/simaple/simulate/component/keydown_skill.py
@@ -1,4 +1,3 @@
-from simaple.simulate.base import Event
 from simaple.simulate.component.base import ReducerState, reducer_method, view_method
 from simaple.simulate.component.entity import Cooldown, Keydown
 from simaple.simulate.component.skill import SkillComponent

--- a/simaple/simulate/component/keydown_skill.py
+++ b/simaple/simulate/component/keydown_skill.py
@@ -1,50 +1,12 @@
-from simaple.simulate.component.base import (
-    Entity,
-    ReducerState,
-    reducer_method,
-    view_method,
-)
-from simaple.simulate.component.entity import Cooldown
+from simaple.simulate.base import Event
+from simaple.simulate.component.base import ReducerState, reducer_method, view_method
+from simaple.simulate.component.entity import Cooldown, Keydown
 from simaple.simulate.component.skill import SkillComponent
-from simaple.simulate.component.view import Validity
+from simaple.simulate.component.trait.impl import (
+    CooldownValidityTrait,
+    KeydownSkillTrait,
+)
 from simaple.simulate.global_property import Dynamics
-
-
-class Keydown(Entity):
-    time_elapsed_after_latest_action: float = 999_999_999
-    time_elapsed_after_first_action: float = 999_999_999
-    running: bool
-
-    def start(self):
-        self.time_elapsed_after_latest_action = 0.0
-        self.time_elapsed_after_first_action = 0.0
-        self.running = True
-
-    def will_keydown_lasts(self, time, maximum_keydown_time: float = 999_999_999):
-        return (self.time_elapsed_after_first_action + time) <= maximum_keydown_time
-
-    def stop(self):
-        self.running = False
-
-    def is_running(self) -> bool:
-        return self.running
-
-    def continue_running(self):
-        self.time_elapsed_after_latest_action = 0.0
-
-    def elapse(self, time, allowed_interval, maximum_keydown_time):
-        self.time_elapsed_after_latest_action += time
-        self.time_elapsed_after_first_action += time
-
-        if self.time_elapsed_after_first_action > maximum_keydown_time:
-            self.stop()
-        elif self.is_running() and self._can_continue_keydown(allowed_interval):
-            return
-        else:
-            self.stop()
-
-    def _can_continue_keydown(self, allowed_interval: float) -> bool:
-        return self.time_elapsed_after_latest_action <= allowed_interval
 
 
 class KeydownSkillState(ReducerState):
@@ -53,15 +15,16 @@ class KeydownSkillState(ReducerState):
     dynamics: Dynamics
 
 
-class KeydownSkillComponent(SkillComponent):
-    maximum_keydown_time: float = 999_999_999
+class KeydownSkillComponent(SkillComponent, KeydownSkillTrait, CooldownValidityTrait):
+    maximum_keydown_time: float
 
     damage: float
     hit: float
     delay: float
     cooldown_duration: float
 
-    keydown_end_delay: float = 0.0
+    keydown_prepare_delay: float
+    keydown_end_delay: float
 
     finish_damage: float = 0.0
     finish_hit: float = 0.0
@@ -69,7 +32,7 @@ class KeydownSkillComponent(SkillComponent):
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "keydown": Keydown(running=False),
+            "keydown": Keydown(interval=self.delay, running=False),
         }
 
     @reducer_method
@@ -78,63 +41,36 @@ class KeydownSkillComponent(SkillComponent):
         _: None,
         state: KeydownSkillState,
     ):
-        state = state.deepcopy()
-
-        if not state.cooldown.available:
-            return state, [self.event_provider.rejected()]
-
-        damage_event = [self.event_provider.dealt(self.damage, self.hit)]
-        delay_event = [self.event_provider.delayed(self.delay)]
-
-        # check user's trigger
-        if not state.keydown.is_running():
-            state.keydown.start()
-
-        # if keydown will end by trigger this action
-        if not state.keydown.will_keydown_lasts(self.delay, self.maximum_keydown_time):
-            # apply cooldown and finisher
-            state.keydown.stop()
-            state.cooldown.set_time_left(
-                state.dynamics.stat.calculate_cooldown(self.cooldown_duration)
-            )
-            damage_event.append(
-                self.event_provider.dealt(self.finish_damage, self.finish_hit)
-            )
-            delay_event.append(self.event_provider.delayed(self.keydown_end_delay))
-        else:
-            state.keydown.continue_running()
-
-        return state, damage_event + delay_event
+        return self.use_keydown_trait(state)
 
     @reducer_method
     def elapse(self, time: float, state: KeydownSkillState):
-        state = state.deepcopy()
+        state, events, _ = self.elapse_keydown_trait(time, state)
+        return state, events
 
-        state.cooldown.elapse(time)
-        was_running = state.keydown.is_running()
-        state.keydown.elapse(time, self.delay, self.maximum_keydown_time)
-
-        events = [self.event_provider.elapsed(time)]
-
-        if was_running and not state.keydown.is_running():
-            state.cooldown.set_time_left(
-                state.dynamics.stat.calculate_cooldown(self.cooldown_duration)
-            )
-
-            # if keydown stopped and finish delay is not zero, compensate un-resolved delay.
-            if self.keydown_end_delay > time:
-                events.append(
-                    self.event_provider.delayed(self.keydown_end_delay - time)
-                )
-                state.cooldown.elapse(self.keydown_end_delay - time)
-
+    @reducer_method
+    def stop(self, _, state: KeydownSkillState):
+        state, events, _ = self.stop_keydown_trait(state)
         return state, events
 
     @view_method
     def validity(self, state: KeydownSkillState):
-        return Validity(
-            name=self.name,
-            time_left=max(0, state.cooldown.time_left),
-            valid=state.cooldown.available,
-            cooldown_duration=self.cooldown_duration,
-        )
+        return self.validity_in_cooldown_trait(state)
+
+    @view_method
+    def keydown(self, state: KeydownSkillState):
+        return self.keydown_view_in_keydown_trait(state)
+
+    def _get_maximum_keydown_time_prepare_delay(self) -> tuple[float, float]:
+        return self.maximum_keydown_time, self.keydown_prepare_delay
+
+    def _get_keydown_damage_hit(self) -> tuple[float, float]:
+        return self.damage, self.hit
+
+    def _get_keydown_end_damage_hit_delay(self) -> tuple[float, float, float]:
+        return self.finish_damage, self.finish_hit, self.keydown_end_delay
+
+    def _on_keydown_end(
+        self, state: KeydownSkillState
+    ) -> tuple[KeydownSkillState, list[Event]]:
+        return state, []

--- a/simaple/simulate/component/keydown_skill.py
+++ b/simaple/simulate/component/keydown_skill.py
@@ -69,8 +69,3 @@ class KeydownSkillComponent(SkillComponent, KeydownSkillTrait, CooldownValidityT
 
     def _get_keydown_end_damage_hit_delay(self) -> tuple[float, float, float]:
         return self.finish_damage, self.finish_hit, self.keydown_end_delay
-
-    def _on_keydown_end(
-        self, state: KeydownSkillState
-    ) -> tuple[KeydownSkillState, list[Event]]:
-        return state, []

--- a/simaple/simulate/component/specific/mechanic.py
+++ b/simaple/simulate/component/specific/mechanic.py
@@ -18,6 +18,7 @@ from simaple.simulate.component.trait.impl import (
     PeriodicWithSimpleDamageTrait,
     UsePeriodicDamageTrait,
 )
+from simaple.simulate.component.util import is_keydown_ended
 from simaple.simulate.component.view import Running
 from simaple.simulate.global_property import Dynamics
 
@@ -310,18 +311,18 @@ class FullMetalBarrageComponent(
     @reducer_method
     def elapse(self, time: float, state: FullMetalBarrageState):
         state.penalty_lasting.elapse(time)
-        state, event, keydown_end = self.elapse_keydown_trait(time, state)
+        state, event = self.elapse_keydown_trait(time, state)
 
-        if keydown_end:
+        if is_keydown_ended(event):
             state.penalty_lasting.set_time_left(self.homing_penalty_duration)
 
         return state, event
 
     @reducer_method
     def stop(self, _, state: FullMetalBarrageState):
-        state, event, keydown_end = self.stop_keydown_trait(state)
+        state, event = self.stop_keydown_trait(state)
 
-        if keydown_end:
+        if is_keydown_ended(event):
             state.penalty_lasting.set_time_left(self.homing_penalty_duration)
 
         return state, event

--- a/simaple/simulate/component/state_protocol.py
+++ b/simaple/simulate/component/state_protocol.py
@@ -1,6 +1,6 @@
 from typing import Protocol, TypeVar
 
-from simaple.simulate.component.entity import Cooldown, Lasting, Periodic
+from simaple.simulate.component.entity import Cooldown, Keydown, Lasting, Periodic
 from simaple.simulate.global_property import Dynamics
 
 T = TypeVar("T")
@@ -30,6 +30,13 @@ class PeriodicProtocol(DeepcopyProtocol, Protocol):
 
 
 PeriodicGeneric = TypeVar("PeriodicGeneric", bound=PeriodicProtocol)
+
+
+class KeydownProtocol(DeepcopyProtocol, Protocol):
+    keydown: Keydown
+
+
+KeydownGeneric = TypeVar("KeydownGeneric", bound=KeydownProtocol)
 
 
 class DynamicsProtocol(DeepcopyProtocol, Protocol):
@@ -76,4 +83,15 @@ class CooldownDynamicsPeriodicProtocol(
 
 CooldownDynamicsPeriodicGeneric = TypeVar(
     "CooldownDynamicsPeriodicGeneric", bound=CooldownDynamicsPeriodicProtocol
+)
+
+
+class CooldownDynamicsKeydownProtocol(
+    CooldownProtocol, KeydownProtocol, DynamicsProtocol, Protocol
+):
+    pass
+
+
+CooldownDynamicsKeydownGeneric = TypeVar(
+    "CooldownDynamicsKeydownGeneric", bound=CooldownDynamicsKeydownProtocol
 )

--- a/simaple/simulate/component/trait/base.py
+++ b/simaple/simulate/component/trait/base.py
@@ -33,6 +33,20 @@ class LastingTrait(ComponentTrait):
         ...
 
 
+class KeydownTrait(ComponentTrait):
+    @abstractmethod
+    def _get_maximum_keydown_time_prepare_delay(self) -> tuple[float, float]:
+        ...
+
+    @abstractmethod
+    def _get_keydown_damage_hit(self) -> tuple[float, float]:
+        ...
+
+    @abstractmethod
+    def _get_keydown_end_damage_hit_delay(self) -> tuple[float, float, float]:
+        ...
+
+
 class SimpleDamageTrait(ComponentTrait):
     @abstractmethod
     def _get_simple_damage_hit(self) -> tuple[float, float]:

--- a/simaple/simulate/component/trait/impl.py
+++ b/simaple/simulate/component/trait/impl.py
@@ -249,12 +249,11 @@ class KeydownSkillTrait(
 
     def elapse_keydown_trait(
         self, time: float, state: CooldownDynamicsKeydownGeneric
-    ) -> tuple[CooldownDynamicsKeydownGeneric, list[Event], bool]:
+    ) -> tuple[CooldownDynamicsKeydownGeneric, list[Event]]:
         state = state.deepcopy()
-        damage, hit = self._get_keydown_damage_hit()
-
         state.cooldown.elapse(time)
 
+        damage, hit = self._get_keydown_damage_hit()
         damage_hits: list[tuple[float, float]] = []
 
         was_running = state.keydown.running
@@ -277,13 +276,13 @@ class KeydownSkillTrait(
         return (
             state,
             [self.event_provider.dealt(damage, hit) for damage, hit in damage_hits]
-            + [self.event_provider.delayed(delay), self.event_provider.elapsed(time)],
-            keydown_end,
+            + [self.event_provider.delayed(delay), self.event_provider.elapsed(time)]
+            + ([self.event_provider.keydown_end()] if keydown_end else []),
         )
 
     def stop_keydown_trait(
         self, state: CooldownDynamicsKeydownGeneric
-    ) -> tuple[CooldownDynamicsKeydownGeneric, list[Event], bool]:
+    ) -> tuple[CooldownDynamicsKeydownGeneric, list[Event]]:
         state = state.deepcopy()
         (
             finish_damage,
@@ -292,7 +291,7 @@ class KeydownSkillTrait(
         ) = self._get_keydown_end_damage_hit_delay()
 
         if not state.keydown.running:
-            return state, [self.event_provider.rejected()], False
+            return state, [self.event_provider.rejected()]
 
         state.keydown.stop()
 
@@ -301,8 +300,8 @@ class KeydownSkillTrait(
             [
                 self.event_provider.dealt(finish_damage, finish_hit),
                 self.event_provider.delayed(finish_delay),
+                self.event_provider.keydown_end(),
             ],
-            True,
         )
 
     def keydown_view_in_keydown_trait(self, state: CooldownDynamicsKeydownProtocol):

--- a/simaple/simulate/component/trait/impl.py
+++ b/simaple/simulate/component/trait/impl.py
@@ -252,11 +252,6 @@ class KeydownSkillTrait(
     ) -> tuple[CooldownDynamicsKeydownGeneric, list[Event], bool]:
         state = state.deepcopy()
         damage, hit = self._get_keydown_damage_hit()
-        (
-            finish_damage,
-            finish_hit,
-            finish_delay,
-        ) = self._get_keydown_end_damage_hit_delay()
 
         state.cooldown.elapse(time)
 
@@ -268,6 +263,11 @@ class KeydownSkillTrait(
 
         keydown_end = was_running and not state.keydown.running
         if keydown_end:
+            (
+                finish_damage,
+                finish_hit,
+                finish_delay,
+            ) = self._get_keydown_end_damage_hit_delay()
             damage_hits += [(finish_damage, finish_hit)]
             # time_left is negative value here, represents time exceeded after actual keydown end.
             delay = max(finish_delay + state.keydown.time_left, 0)

--- a/simaple/simulate/component/util.py
+++ b/simaple/simulate/component/util.py
@@ -4,3 +4,7 @@ from simaple.simulate.reserved_names import Tag
 
 def is_rejected(events: list[Event]) -> bool:
     return any(event.tag == Tag.REJECT for event in events)
+
+
+def is_keydown_ended(events: list[Event]) -> bool:
+    return any(event.tag == Tag.KEYDOWN_END for event in events)

--- a/simaple/simulate/component/view.py
+++ b/simaple/simulate/component/view.py
@@ -21,6 +21,12 @@ class Running(pydantic.BaseModel):
     stack: Optional[float] = None
 
 
+class KeydownView(pydantic.BaseModel):
+    name: str
+    time_left: float
+    running: bool
+
+
 class ValidityParentView(AggregationView):
     """A View for valid-skill set
     Gathers view name `validity`, returns each component's validity(which
@@ -61,3 +67,12 @@ class BuffParentView(AggregationView):
     @classmethod
     def get_installation_pattern(cls):
         return r".*\.buff"
+
+
+class KeydownParentView(AggregationView):
+    def aggregate(self, representations: list[KeydownView]):
+        return representations
+
+    @classmethod
+    def get_installation_pattern(cls):
+        return r".*\.keydown"

--- a/simaple/simulate/event.py
+++ b/simaple/simulate/event.py
@@ -25,6 +25,10 @@ class EventProvider(metaclass=ABCMeta):
     ) -> Event:
         ...
 
+    @abstractmethod
+    def keydown_end(self) -> Event:
+        ...
+
 
 class NamedEventProvider(EventProvider):
     def __init__(self, name: str, default_modifier: Optional[Stat] = None):
@@ -62,3 +66,6 @@ class NamedEventProvider(EventProvider):
                 "modifier": total_modifier.dict() if total_modifier else None,
             },
         )
+
+    def keydown_end(self) -> Event:
+        return Event(name=self._name, tag=Tag.KEYDOWN_END)

--- a/simaple/simulate/kms.py
+++ b/simaple/simulate/kms.py
@@ -8,6 +8,7 @@ from simaple.simulate.base import AddressedStore, Client, ConcreteStore, Environ
 from simaple.simulate.component.base import Component
 from simaple.simulate.component.view import (
     BuffParentView,
+    KeydownParentView,
     RunningParentView,
     ValidityParentView,
 )
@@ -71,5 +72,6 @@ def get_client(
     ValidityParentView.build_and_install(environment, "validity")
     BuffParentView.build_and_install(environment, "buff")
     RunningParentView.build_and_install(environment, "running")
+    KeydownParentView.build_and_install(environment, "keydown")
 
     return client

--- a/simaple/simulate/reserved_names.py
+++ b/simaple/simulate/reserved_names.py
@@ -7,5 +7,6 @@ class Tag:
     REJECT = "global.reject"
     DELAY = "global.delay"
     DAMAGE = "global.damage"
+    KEYDOWN_END = "global.keydown_end"
     DOT = "global.dot"
     MOB = "global.mob"

--- a/tests/simulate/component/test_keydown_component.py
+++ b/tests/simulate/component/test_keydown_component.py
@@ -6,113 +6,192 @@ from simaple.simulate.component.keydown_skill import (
     KeydownSkillState,
 )
 from simaple.simulate.global_property import Dynamics
-from tests.simulate.component.util import is_rejected
+from simaple.simulate.reserved_names import Tag
+from tests.simulate.component.util import count_damage_skill, is_rejected, total_delay
 
 
-@pytest.fixture
-def keydown_delay():
-    return 300
-
-
-@pytest.fixture
-def keydown_component(keydown_delay: float):
-    return KeydownSkillComponent(
+@pytest.fixture(name="keydown_fixture", params=[300, 500, 800])
+def keydown_fixture(request, dynamics: Dynamics):
+    delay: float = request.param
+    component = KeydownSkillComponent(
         name="test-keydown",
         damage=100,
         hit=3,
         cooldown_duration=60_000,
-        delay=keydown_delay,
+        delay=delay,
+        maximum_keydown_time=delay * 10,
+        keydown_prepare_delay=delay * 2,
         keydown_end_delay=500,
         finish_damage=500,
         finish_hit=15,
-        maximum_keydown_time=keydown_delay * 10,
     )
-
-
-@pytest.fixture
-def keydown_state(keydown_component: KeydownSkillComponent, dynamics: Dynamics):
-    return KeydownSkillState.parse_obj(
+    state = KeydownSkillState.parse_obj(
         {
-            **keydown_component.get_default_state(),
+            **component.get_default_state(),
             "dynamics": dynamics,
         }
     )
+    return (component, state, delay)
 
 
-def test_reject(
-    keydown_component: KeydownSkillComponent, keydown_state: KeydownSkillState
+def test_use_reject(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
 ):
+    # given
+    component, state, _ = keydown_fixture
+
     # when
-    state, _ = keydown_component.use(None, keydown_state)
-    state, _ = keydown_component.elapse(10_000, state)
-    state, events = keydown_component.use(None, state)
+    state, _ = component.use(None, state)
+    state, _ = component.elapse(10_000, state)
+    state, events = component.use(None, state)
 
     # then
     assert is_rejected(events)
 
 
-def test_use_keydown_component(
-    keydown_component: KeydownSkillComponent, keydown_state: KeydownSkillState
+def test_stop_reject(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
 ):
+    # given
+    component, state, _ = keydown_fixture
+
     # when
-    state, _ = keydown_component.use(None, keydown_state)
+    state, events = component.stop(None, state)
 
     # then
-    assert state.keydown.is_running()
+    assert is_rejected(events)
 
 
-def test_use_keydown_component_and_elapse_time(
-    keydown_component: KeydownSkillComponent,
-    keydown_state: KeydownSkillState,
-    keydown_delay: float,
-):
+def test_use(keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]):
+    # given
+    component, state, _ = keydown_fixture
+
     # when
-    state, _ = keydown_component.use(None, keydown_state)
-    state, _ = keydown_component.elapse(keydown_delay, state)
+    state, _ = component.use(None, state)
 
     # then
-    assert state.keydown.is_running()
+    assert state.keydown.running is True
 
 
-def test_use_keydown_component_and_elapse_more_time(
-    keydown_component: KeydownSkillComponent,
-    keydown_state: KeydownSkillState,
-    keydown_delay: float,
+def test_use_and_stop(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
 ):
+    # given
+    component, state, _ = keydown_fixture
+
     # when
-    state, _ = keydown_component.use(None, keydown_state)
-    state, events = keydown_component.elapse(keydown_delay + 10, state)
+    state, _ = component.use(None, state)
+    state, events = component.stop(None, state)
 
     # then
-    assert not state.keydown.is_running()
-    assert events[-1].payload["time"] == 500 - 10 - keydown_delay
+    damage_events = [e for e in events if e.tag == Tag.DAMAGE]
+    assert damage_events[-1].payload["damage"] == component.finish_damage
+    assert damage_events[-1].payload["hit"] == component.finish_hit
+    assert total_delay(events) == component.keydown_end_delay
+    assert state.keydown.running is False
 
 
-def test_use_keydown_component_many_time(
-    keydown_component: KeydownSkillComponent,
-    keydown_state: KeydownSkillState,
-    keydown_delay: float,
+def test_use_and_elapse_lesser_than_prepare_delay(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
 ):
+    # given
+    component, state, delay = keydown_fixture
+    to_elapse = delay * 2 - 10
+
     # when
-    state = keydown_state
-    for _ in range(6):
-        state, _ = keydown_component.use(None, state)
-        state, _ = keydown_component.elapse(keydown_delay, state)
+    state, _ = component.use(None, state)
+    state, events = component.elapse(to_elapse, state)
 
     # then
-    assert state.keydown.is_running()
+    assert count_damage_skill(events) == 0
+    assert total_delay(events) == 0
 
 
-def test_use_keydown_component_too_long(
-    keydown_component: KeydownSkillComponent,
-    keydown_state: KeydownSkillState,
-    keydown_delay: float,
+def test_use_and_elapse_equals_prepare_delay(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
 ):
+    # given
+    component, state, delay = keydown_fixture
+    to_elapse = delay * 2
+
     # when
-    state = keydown_state
-    for _ in range(11):
-        state, _ = keydown_component.use(None, state)
-        state, _ = keydown_component.elapse(keydown_delay, state)
+    state, _ = component.use(None, state)
+    state, events = component.elapse(to_elapse, state)
 
     # then
-    assert not state.keydown.is_running()
+    assert count_damage_skill(events) == 1
+    assert total_delay(events) == delay
+
+
+def test_use_and_elapse_greater_than_prepare_delay(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
+):
+    # given
+    component, state, delay = keydown_fixture
+    to_elapse = delay * 2 + 10
+
+    # when
+    state, _ = component.use(None, state)
+    state, events = component.elapse(to_elapse, state)
+
+    # then
+    assert count_damage_skill(events) == 1
+    assert total_delay(events) == delay
+
+
+def test_elapse_until_finish(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
+):
+    # given
+    component, state, delay = keydown_fixture
+
+    # when
+    state, use_events = component.use(None, state)
+    state, elapse_events = component.elapse(delay * 10, state)
+
+    # then
+    print(use_events)
+    damage_events = [e for e in elapse_events if e.tag == Tag.DAMAGE]
+    assert damage_events[-1].payload["damage"] == component.finish_damage
+    assert damage_events[-1].payload["hit"] == component.finish_hit
+    assert (
+        total_delay(use_events + elapse_events)
+        == component.maximum_keydown_time + component.keydown_end_delay
+    )
+    assert state.keydown.running is False
+
+
+def test_elapse_just_before_finish(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
+):
+    # given
+    component, state, delay = keydown_fixture
+
+    # when
+    state, _ = component.use(None, state)
+    state, _ = component.elapse(delay * 10 - 10, state)
+
+    # then
+    assert state.keydown.running is True
+
+
+def test_elapse_very_long(
+    keydown_fixture: tuple[KeydownSkillComponent, KeydownSkillState, float]
+):
+    # given
+    component, state, delay = keydown_fixture
+
+    # when
+    state, use_events = component.use(None, state)
+    state, elapse_events = component.elapse(delay * 20, state)
+
+    # then
+    print(use_events)
+    damage_events = [e for e in elapse_events if e.tag == Tag.DAMAGE]
+    assert damage_events[-1].payload["damage"] == component.finish_damage
+    assert damage_events[-1].payload["hit"] == component.finish_hit
+    assert (
+        total_delay(use_events + elapse_events)
+        == component.maximum_keydown_time + component.keydown_end_delay
+    )
+    assert state.keydown.running is False

--- a/tests/simulate/component/test_keydown_component.py
+++ b/tests/simulate/component/test_keydown_component.py
@@ -150,7 +150,6 @@ def test_elapse_until_finish(
     state, elapse_events = component.elapse(delay * 10, state)
 
     # then
-    print(use_events)
     damage_events = [e for e in elapse_events if e.tag == Tag.DAMAGE]
     assert damage_events[-1].payload["damage"] == component.finish_damage
     assert damage_events[-1].payload["hit"] == component.finish_hit
@@ -186,7 +185,6 @@ def test_elapse_very_long(
     state, elapse_events = component.elapse(delay * 20, state)
 
     # then
-    print(use_events)
     damage_events = [e for e in elapse_events if e.tag == Tag.DAMAGE]
     assert damage_events[-1].payload["damage"] == component.finish_damage
     assert damage_events[-1].payload["hit"] == component.finish_hit

--- a/tests/simulate/component/test_keydown_entity.py
+++ b/tests/simulate/component/test_keydown_entity.py
@@ -11,7 +11,7 @@ from simaple.simulate.component.keydown_skill import Keydown
         (750, 8),
     ],
 )
-def test_keydown_count(time, expected):
+def test_keydown_simple_count(time, expected):
     # given
     keydown = Keydown(interval=100)
     keydown.start(maximum_keydown_time=1200, prepare_delay=0)
@@ -28,16 +28,18 @@ def test_keydown_count(time, expected):
 @pytest.mark.parametrize(
     "elapse_time, maximum_keydown_time, prepare_delay, interval, expected",
     [
-        (100, 450, 0, 100, (100, 100)),
-        (150, 450, 0, 100, (100, 100)),
-        (500, 450, 0, 100, (100, 100, 100, 100, 50)),
-        (600, 2400, 600, 300, (300,)),
-        (2400, 2400, 0, 300, (300, 300, 300, 300, 300, 300, 300, 300, 0)),
-        (3000, 3000, 600, 300, (300, 300, 300, 300, 300, 300, 300, 300, 0)),
-        (10000, 8160, 240, 1020, (1020, 1020, 1020, 1020, 1020, 1020, 1020, 780)),
+        (100, 450, 0, 100, 2),
+        (150, 450, 0, 100, 2),
+        (500, 450, 0, 100, 5),
+        (600, 2400, 600, 300, 1),
+        (899, 2400, 600, 300, 1),
+        (900, 2400, 600, 300, 2),
+        (2400, 2400, 0, 300, 9),
+        (3000, 3000, 600, 300, 9),
+        (10000, 8160, 240, 1020, 8),
     ],
 )
-def test_keydown_delay(
+def test_keydown_complex_count(
     elapse_time: float,
     maximum_keydown_time: float,
     prepare_delay: float,
@@ -51,20 +53,23 @@ def test_keydown_delay(
     )
 
     # when
-    delays = tuple(keydown.resolving(elapse_time))
+    resolved_count = len(list(keydown.resolving(elapse_time)))
 
     # then
-    assert delays == expected
+    assert resolved_count == expected
 
 
 @pytest.mark.parametrize(
-    "elapse_time, maximum_keydown_time, prepare_delay, interval, expected",
+    "schedule, maximum_keydown_time, prepare_delay, interval, expected",
     [
-        (1020, 8160, 240, 1020, (1020, 1020, 1020, 1020, 1020, 1020, 1020, 780)),
+        ([1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 160], 8160, 240, 1020, 8),
+        ([8160], 8160, 240, 1020, 8),
+        ([500, 600, 700, 800, 900, 1000, 1500, 2000, 4000], 8160, 240, 1020, 8),
+        ([240], 8160, 240, 1020, 1),
     ],
 )
 def test_keydown_multiple_elapse(
-    elapse_time: float,
+    schedule: list[float],
     maximum_keydown_time: float,
     prepare_delay: float,
     interval: float,
@@ -77,9 +82,9 @@ def test_keydown_multiple_elapse(
     )
 
     # when
-    delays = []
-    for _ in range(30):
-        delays += list(keydown.resolving(elapse_time))
+    resolved_count = 0
+    for elapse_time in schedule:
+        resolved_count += len(list(keydown.resolving(elapse_time)))
 
     # then
-    assert tuple(delays) == expected
+    assert resolved_count == expected

--- a/tests/simulate/component/test_keydown_entity.py
+++ b/tests/simulate/component/test_keydown_entity.py
@@ -1,0 +1,85 @@
+import pytest
+
+from simaple.simulate.component.keydown_skill import Keydown
+
+
+@pytest.mark.parametrize(
+    "time, expected",
+    [
+        (1500, 13),
+        (300, 4),
+        (750, 8),
+    ],
+)
+def test_keydown_count(time, expected):
+    # given
+    keydown = Keydown(interval=100)
+    keydown.start(maximum_keydown_time=1200, prepare_delay=0)
+
+    # when
+    count = 0
+    for _ in keydown.resolving(time):
+        count += 1
+
+    # then
+    assert count == expected
+
+
+@pytest.mark.parametrize(
+    "elapse_time, maximum_keydown_time, prepare_delay, interval, expected",
+    [
+        (100, 450, 0, 100, (100, 100)),
+        (150, 450, 0, 100, (100, 100)),
+        (500, 450, 0, 100, (100, 100, 100, 100, 50)),
+        (600, 2400, 600, 300, (300,)),
+        (2400, 2400, 0, 300, (300, 300, 300, 300, 300, 300, 300, 300, 0)),
+        (3000, 3000, 600, 300, (300, 300, 300, 300, 300, 300, 300, 300, 0)),
+        (10000, 8160, 240, 1020, (1020, 1020, 1020, 1020, 1020, 1020, 1020, 780)),
+    ],
+)
+def test_keydown_delay(
+    elapse_time: float,
+    maximum_keydown_time: float,
+    prepare_delay: float,
+    interval: float,
+    expected: tuple[float],
+):
+    # given
+    keydown = Keydown(interval=interval)
+    keydown.start(
+        maximum_keydown_time=maximum_keydown_time, prepare_delay=prepare_delay
+    )
+
+    # when
+    delays = tuple(keydown.resolving(elapse_time))
+
+    # then
+    assert delays == expected
+
+
+@pytest.mark.parametrize(
+    "elapse_time, maximum_keydown_time, prepare_delay, interval, expected",
+    [
+        (1020, 8160, 240, 1020, (1020, 1020, 1020, 1020, 1020, 1020, 1020, 780)),
+    ],
+)
+def test_keydown_multiple_elapse(
+    elapse_time: float,
+    maximum_keydown_time: float,
+    prepare_delay: float,
+    interval: float,
+    expected: tuple[float],
+):
+    # given
+    keydown = Keydown(interval=interval)
+    keydown.start(
+        maximum_keydown_time=maximum_keydown_time, prepare_delay=prepare_delay
+    )
+
+    # when
+    delays = []
+    for _ in range(30):
+        delays += list(keydown.resolving(elapse_time))
+
+    # then
+    assert tuple(delays) == expected

--- a/tests/simulate/component/util.py
+++ b/tests/simulate/component/util.py
@@ -9,6 +9,16 @@ def count_damage_skill(events: list[Event]) -> int:
     return sum([e.tag == Tag.DAMAGE for e in events])
 
 
+def total_delay(events: list[Event]) -> int:
+    return sum(
+        [
+            e.payload["time"]
+            for e in events
+            if e.tag == Tag.DELAY and e.payload is not None
+        ]
+    )
+
+
 def count_dot_skill(events: list[Event]) -> int:
     return sum([e.tag == Tag.DOT for e in events])
 

--- a/tests/simulate/report/archmagetc/test_dpm.py
+++ b/tests/simulate/report/archmagetc/test_dpm.py
@@ -61,4 +61,4 @@ def test_actor(character_stat):
 
     print(f"{environment.show('clock')} | {dpm_calculator.calculate_dpm(report):,} ")
 
-    assert int(dpm_calculator.calculate_dpm(report)) == 1_337_872_270_583
+    assert int(dpm_calculator.calculate_dpm(report)) == 1_228_822_734_458

--- a/tests/simulate/report/archmagetc/test_dpm.py
+++ b/tests/simulate/report/archmagetc/test_dpm.py
@@ -61,4 +61,4 @@ def test_actor(character_stat):
 
     print(f"{environment.show('clock')} | {dpm_calculator.calculate_dpm(report):,} ")
 
-    assert int(dpm_calculator.calculate_dpm(report)) == 1_228_822_734_458
+    assert int(dpm_calculator.calculate_dpm(report)) == 1_242_953_386_834

--- a/tests/simulate/report/bishop/test_dpm.py
+++ b/tests/simulate/report/bishop/test_dpm.py
@@ -65,4 +65,4 @@ def test_actor(character_stat):
     print(f"{environment.show('clock')} | {dpm_calculator.calculate_dpm(report):,} ")
     report.save("report.tsv")
 
-    assert int(dpm_calculator.calculate_dpm(report)) == 1_188_622_490_113
+    assert int(dpm_calculator.calculate_dpm(report)) == 1_176_076_251_714

--- a/tests/simulate/report/mechanic/test_mechanic.py
+++ b/tests/simulate/report/mechanic/test_mechanic.py
@@ -59,4 +59,4 @@ def test_actor(mechanic_client, character_stat):
             rec.write(action, environment.show("clock"))
 
     print(f"{environment.show('clock')} | {dpm_calculator.calculate_dpm(report):,} ")
-    assert int(dpm_calculator.calculate_dpm(report)) == 2_511_974_882_309
+    assert int(dpm_calculator.calculate_dpm(report)) == 2_434_603_724_080


### PR DESCRIPTION
## Problem statement

기존 구현 방식은 이전 키다운 delay 후에 Use가 다시 발생하면 이것을 "유저가 키다운을 유지할 의지가 있다"라고 판단하고 키다운 판정을 이어나가고, Use 없이 delay보다 긴 시간이 흐르면 "키다운을 유지하지 않았다"라고 판단하고 종료 판정을 발생시키는 방식이였다.

하지만, 이 방식은 다음과 같은 문제를 가지고 있었다.
* use()에 1:1로 대응되는 인게임 조작이 존재하지 않는다.
* keydown_end 관련 처리가 난해하다.
  * (버그) 전체 키다운 시간은 maximum_keydown_time을 초과하지 않으므로 마지막 use()의 delay는 self.delay보다 짧을 수 있다.
  * (버그) use()가 keydown_end_delay를 함께 발생시키는 경우 delay event가 2번 전달되는데, AlwaysDelayedActor의 동작상 첫번째 delay event만 적용되고 있었다.
  * elapse()에서 keydown_end가 발생하는 경우 실제 keydown_end가 언제 발생했는지 모호하다.
  * interval=100, time_left=10인 경우 elapse(50)을 하면 keydown_end는 언제 발생한 것인가? 0? 10? 상식적으로 10이지만, 그렇다면 `self.event_provider.delayed(self.keydown_end_delay - time)`는 성립할 수 없다. 
* (off-topic) 쿨다운이 `use` 시점부터 도는것이 실제 동작이나, `stop` 시점부터 돌고 있었다.

## TO-BE
* `use`를 "키다운 시작", `elapse`를 "현상태 유지"로 정의하고, 키다운을 중지하는 `stop` 리듀서를 추가한다.
  * keydown_end가 발생하는 시점을 "maximum_keydown_time 초과", "명시적인 stop" 두개로 한정해 모호성을 제거한다.
* 키다운이 진행중인지 알리는 `keydown` 뷰를 추가해, 다른 스킬을 사용하려면 `keydown`을 먼저 종료시켜야 함을 알린다.
* 쿨다운은 `stop`이 아닌 `use` 시점부터 진행된다.

## use()
* 키다운을 Use하면 prepare_delay만큼 딜레이가 발생하고, `state.keydown.time_left`를 세팅한다.

## elapse()
* elapse 결과 키다운이 종료되었거나, stop이 호출된 경우 keydown_end_delay 만큼의 딜레이 이벤트가 발생한다.
* 키다운을 Elapse하면 전달된 time 사이에 발생한 데미지 이벤트를 반환한다. 최초 데미지는 prepare_time이 끝난 직후 발생한다.
* time_left가 interval로 나뉘어 떨어지는 경우, 마지막 틱이 발생한다.
  * 300ms가 남았을 때, 100ms의 interval을 가지는 키다운을 elapse(300) 하면 4회의 damage event가 발생한다.

## stop()
  * `stop`은 `dealt(finish_damage, hit)` 및 `delayed(keydown_end_delay)`를 발생시킨다.

