### PR TITLE
refactor: store as entity storage

### DIFF
--- a/simaple/simulate/global_property.py
+++ b/simaple/simulate/global_property.py
@@ -18,8 +18,8 @@ class GlobalProperty:
         self._action_stat = action_stat
 
     def install_global_properties(self, store: Store):
-        store.set_state("global.dynamics", Dynamics(stat=self._action_stat))
-        store.set_state("global.time", Clock())
+        store.set_entity("global.dynamics", Dynamics(stat=self._action_stat))
+        store.set_entity("global.time", Clock())
 
     @classmethod
     def get_default_binds(cls):

--- a/simaple/simulate/timer.py
+++ b/simaple/simulate/timer.py
@@ -7,15 +7,15 @@ def timer_delay_dispatcher(action: Action, store: Store) -> list[Event]:
     if action.method != "elapse" and action.name != "*":
         return []
 
-    time_state, set_time_state = store.use_state("global.time", Clock())
+    clock, set_clock = store.use_entity("global.time", Clock())
 
-    time_state.spent(action.payload)
-    set_time_state(time_state)
+    clock.spent(action.payload)
+    set_clock(clock)
     return []
 
 
 def clock_view(store: Store) -> float:
-    time: float = store.read_state("global.time", Clock()).current_time
+    time: float = store.read_entity("global.time", Clock()).current_time
     return time
 
 

--- a/tests/simulate/component/specific/adele/conftest.py
+++ b/tests/simulate/component/specific/adele/conftest.py
@@ -34,7 +34,7 @@ def global_property():
 def adele_store(global_property):
     store = AddressedStore(ConcreteStore())
     global_property.install_global_properties(store)
-    store.set_state(
+    store.set_entity(
         ".에테르.ether_gauge",
         EtherGauge(
             maximum_stack=400,
@@ -42,7 +42,7 @@ def adele_store(global_property):
             order_consume=100,
         ),
     )
-    store.set_state(
+    store.set_entity(
         ".리스토어(버프).lasting",
         RestoreLasting(time_left=0, ether_multiplier=80),
     )

--- a/tests/simulate/component/specific/adele/test_blossom.py
+++ b/tests/simulate/component/specific/adele/test_blossom.py
@@ -21,7 +21,7 @@ def fixture_blossom(
 
 
 def test_blossom_order_1pair(adele_store, blossom):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".오더.order_sword",
         OrderSword(interval=1020, running_swords=[(0, 40000)]),
     )
@@ -32,7 +32,7 @@ def test_blossom_order_1pair(adele_store, blossom):
 
 
 def test_blossom_order_3pair(adele_store, blossom):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".오더.order_sword",
         OrderSword(interval=1020, running_swords=[(0, 40000), (0, 40000), (0, 40000)]),
     )

--- a/tests/simulate/component/specific/adele/test_ether.py
+++ b/tests/simulate/component/specific/adele/test_ether.py
@@ -17,7 +17,7 @@ def test_ether_resonance(ether):
 
 
 def test_ether_order_consume(adele_store, ether):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".에테르.ether_gauge",
         EtherGauge(
             stack=100,

--- a/tests/simulate/component/specific/adele/test_gathering.py
+++ b/tests/simulate/component/specific/adele/test_gathering.py
@@ -22,7 +22,7 @@ def fixture_gathering(
 
 
 def test_gathering_order_1pair(adele_store, gathering):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".오더.order_sword",
         OrderSword(interval=1020, running_swords=[(0, 40000)]),
     )
@@ -33,7 +33,7 @@ def test_gathering_order_1pair(adele_store, gathering):
 
 
 def test_gathering_order_3pair(adele_store, gathering):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".오더.order_sword",
         OrderSword(interval=1020, running_swords=[(0, 40000), (0, 40000), (0, 40000)]),
     )

--- a/tests/simulate/component/specific/adele/test_order.py
+++ b/tests/simulate/component/specific/adele/test_order.py
@@ -2,7 +2,7 @@ from simaple.simulate.component.specific.adele import EtherGauge
 
 
 def test_order_count(adele_store, order):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".에테르.ether_gauge",
         EtherGauge(
             stack=400,
@@ -22,7 +22,7 @@ def test_order_count(adele_store, order):
 
 
 def test_order_elapse(adele_store, order):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".에테르.ether_gauge",
         EtherGauge(
             stack=400,

--- a/tests/simulate/component/specific/adele/test_storm.py
+++ b/tests/simulate/component/specific/adele/test_storm.py
@@ -22,7 +22,7 @@ def fixture_storm(
 
 
 def test_storm_order_1pair(adele_store, storm):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".오더.order_sword",
         OrderSword(interval=1020, running_swords=[(0, 40000)]),
     )
@@ -35,7 +35,7 @@ def test_storm_order_1pair(adele_store, storm):
 
 
 def test_storm_order_3pair(adele_store, storm):
-    adele_store.set_state(
+    adele_store.set_entity(
         ".오더.order_sword",
         OrderSword(interval=1020, running_swords=[(0, 40000), (0, 40000), (0, 40000)]),
     )

--- a/tests/simulate/component/specific/archmagetc/conftest.py
+++ b/tests/simulate/component/specific/archmagetc/conftest.py
@@ -32,7 +32,7 @@ def global_property():
 def archmagetc_store(global_property):
     store = AddressedStore(ConcreteStore())
     global_property.install_global_properties(store)
-    store.set_state(".주피터 썬더.periodic", Periodic(interval=120))
+    store.set_entity(".주피터 썬더.periodic", Periodic(interval=120))
     return store
 
 

--- a/tests/simulate/component/specific/mechanic/conftest.py
+++ b/tests/simulate/component/specific/mechanic/conftest.py
@@ -31,7 +31,7 @@ def global_property():
 def mechanic_store(global_property):
     store = AddressedStore(ConcreteStore())
     global_property.install_global_properties(store)
-    store.set_state(
+    store.set_entity(
         ".로봇 마스터리.robot_mastery",
         RobotMastery(
             summon_increment=40,

--- a/tests/simulate/test_save_load.py
+++ b/tests/simulate/test_save_load.py
@@ -5,7 +5,7 @@ from simaple.simulate.component.entity import Cooldown, Lasting, Periodic
 def test_store_save_load():
     store = ConcreteStore()
 
-    store.set_state(
+    store.set_entity(
         "dur",
         Lasting(
             time_left=3.0,
@@ -13,14 +13,14 @@ def test_store_save_load():
         ),
     )
 
-    store.set_state(
+    store.set_entity(
         "x.cooldown",
         Cooldown(
             time_left=3.0,
         ),
     )
 
-    store.set_state(
+    store.set_entity(
         "y.interval",
         Periodic(
             interval_counter=3.0,
@@ -35,10 +35,10 @@ def test_store_save_load():
     new_store = ConcreteStore()
     new_store.load(saved_store)
 
-    assert store.read_state("dur", None) == new_store.read_state("dur", None)
-    assert store.read_state("x.cooldown", None) == new_store.read_state(
+    assert store.read_entity("dur", None) == new_store.read_entity("dur", None)
+    assert store.read_entity("x.cooldown", None) == new_store.read_entity(
         "x.cooldown", None
     )
-    assert store.read_state("y.interval", None) == new_store.read_state(
+    assert store.read_entity("y.interval", None) == new_store.read_entity(
         "y.interval", None
     )


### PR DESCRIPTION
* `Store`는 `Entity` 단위로 상태를 저장하고 로드한다.
* `Component`는 `StoreAdapter`를 통해 `Entity`를 wire한 형태의 `State` 단위로 상태를 받아오고 반환한다.